### PR TITLE
fix: fix float sql encoding

### DIFF
--- a/float32.go
+++ b/float32.go
@@ -53,7 +53,7 @@ func (f *Float32) Scan(src any) error {
 }
 
 // Value returns the value for satisfying the driver.Valuer interface.
-func (f *Float32) Value() (driver.Value, error) {
+func (f Float32) Value() (driver.Value, error) {
 	return sql.NullFloat64{
 		Float64: float64(f.Float32),
 		Valid:   f.Valid,

--- a/float64.go
+++ b/float64.go
@@ -53,7 +53,7 @@ func (f *Float64) Scan(src any) error {
 }
 
 // Value returns the value for satisfying the driver.Valuer interface.
-func (f *Float64) Value() (driver.Value, error) {
+func (f Float64) Value() (driver.Value, error) {
 	return sql.NullFloat64{
 		Float64: f.Float64,
 		Valid:   f.Valid,


### PR DESCRIPTION
The Value functions in both float32.go and float64.go have been updated so that they are non-pointer receivers. This change ensures the Valuer interface is satisfied and properly implemented by the Float32 and Float64 types.