### PR TITLE
feat: allow easier usage of exhaustruct linter

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -9,7 +9,7 @@ import (
 // Bool holds a nullable boolean value.
 type Bool struct {
 	// Bool is the actual boolean value when Valid.
-	Bool bool
+	Bool bool `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/byte_slice.go
+++ b/byte_slice.go
@@ -10,7 +10,7 @@ import (
 // ByteSlice holds a nullable byte slice.
 type ByteSlice struct {
 	// ByteSlice is the actual byte slice when Valid.
-	ByteSlice []byte
+	ByteSlice []byte `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/float32.go
+++ b/float32.go
@@ -9,7 +9,7 @@ import (
 // Float32 holds a nullable float32.
 type Float32 struct {
 	// Float32 is the actual value when Valid.
-	Float32 float32
+	Float32 float32 `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/float64.go
+++ b/float64.go
@@ -9,7 +9,7 @@ import (
 // Float64 holds a nullable float64.
 type Float64 struct {
 	// Float64 is the actual value when Valid.
-	Float64 float64
+	Float64 float64 `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/int.go
+++ b/int.go
@@ -9,7 +9,7 @@ import (
 // Int holds a nullable int.
 type Int struct {
 	// Int is the actual value when Valid.
-	Int int
+	Int int `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/int16.go
+++ b/int16.go
@@ -9,7 +9,7 @@ import (
 // Int16 holds a nullable int16.
 type Int16 struct {
 	// Int16 is the actual value when Valid.
-	Int16 int16
+	Int16 int16 `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/int32.go
+++ b/int32.go
@@ -9,7 +9,7 @@ import (
 // Int32 holds a nullable int32.
 type Int32 struct {
 	// Int32 is the actual value when Valid.
-	Int32 int32
+	Int32 int32 `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/int64.go
+++ b/int64.go
@@ -9,7 +9,7 @@ import (
 // Int64 holds a nullable int64.
 type Int64 struct {
 	// Int64 is the actual value when Valid.
-	Int64 int64
+	Int64 int64 `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/json_nullable.go
+++ b/json_nullable.go
@@ -10,7 +10,7 @@ import (
 // (un)marshallable. However, it cannot be used as sql.Scanner or driver.Valuer.
 type JSONNullable[T any] struct {
 	// V is the actual value when Valid.
-	V T
+	V T `exhaustruct:"optional"`
 	// Valid describes whether the JSONNullable does not hold a NULL value.
 	Valid bool
 }

--- a/json_raw_message.go
+++ b/json_raw_message.go
@@ -10,7 +10,7 @@ import (
 // value will be represented with Valid being false.
 type JSONRawMessage struct {
 	// RawMessage is the actual json.RawMessage when Valid.
-	RawMessage json.RawMessage
+	RawMessage json.RawMessage `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/nullable.go
+++ b/nullable.go
@@ -16,7 +16,7 @@ type NullableValue interface {
 // Nullable holds a nullable value.
 type Nullable[T NullableValue] struct {
 	// V is the actual value when Valid.
-	V T
+	V T `exhaustruct:"optional"`
 	// Valid describes whether the Nullable does not hold a NULL value.
 	Valid bool
 }

--- a/nullable_into.go
+++ b/nullable_into.go
@@ -18,7 +18,7 @@ type NullableIntoValue[T any] interface {
 // reference.
 type NullableInto[T NullableIntoValue[T]] struct {
 	// V is the actual value when Valid.
-	V T
+	V T `exhaustruct:"optional"`
 	// Valid describes whether the Nullable does not hold a NULL value.
 	Valid bool
 }

--- a/optional.go
+++ b/optional.go
@@ -10,7 +10,7 @@ import (
 // NullableInto if database support is not required.
 type Optional[T any] struct {
 	// V is the actual value when Valid.
-	V T
+	V T `exhaustruct:"optional"`
 	// Valid describes whether the Nullable does not hold a NULL value.
 	Valid bool
 }

--- a/string.go
+++ b/string.go
@@ -9,7 +9,7 @@ import (
 // String holds a nullable string.
 type String struct {
 	// String is the actual value when Valid.
-	String string
+	String string `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }

--- a/time.go
+++ b/time.go
@@ -10,7 +10,7 @@ import (
 // Time holds a nullable time.Time.
 type Time struct {
 	// Time is the actual value when Valid.
-	Time time.Time
+	Time time.Time `exhaustruct:"optional"`
 	// Valid when no NULL-value is represented.
 	Valid bool
 }


### PR DESCRIPTION
Adds the exhaustruct-optional-tag to value fields of nullables. This still enforces setting valid to false if providing a null value but not the content field. For setting a non-null value, users are still expected to use the constructor functions.